### PR TITLE
final modification after code review.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Account query fix #103
 - nft multisig test done
 - enable codec for fungible and nonfungible token in multisig.
+- symbol length change to 40
+- added validation for decimal in ft (token decimal not allow to be 0 or greater than 18)
+- disable rpc end point for listing token and nonfungible token 
 
 # Version 1.2.1
 - Adding non fungible token module

--- a/app/app.go
+++ b/app/app.go
@@ -304,8 +304,8 @@ func NewMXWApp(logger log.Logger, db dbm.DB) *mxwApp {
 	// We need to customized it
 	rpccore.Routes["debug/fee_info"] = rpc.NewRPCFunc(app.FeeInfo, "")
 	rpccore.Routes["debug/kyc_info"] = rpc.NewRPCFunc(app.KYCInfo, "")
-	rpccore.Routes["debug/fungible_token_list"] = rpc.NewRPCFunc(app.FungibleTokenList, "")
-	rpccore.Routes["debug/non_fungible_token_list"] = rpc.NewRPCFunc(app.NonFungibleTokenList, "")
+	//rpccore.Routes["debug/fungible_token_list"] = rpc.NewRPCFunc(app.FungibleTokenList, "")
+	//rpccore.Routes["debug/non_fungible_token_list"] = rpc.NewRPCFunc(app.NonFungibleTokenList, "")
 
 	delete(rpccore.Routes, "genesis")
 

--- a/x/token/fungible/msgs.go
+++ b/x/token/fungible/msgs.go
@@ -91,6 +91,10 @@ func (msg MsgCreateFungibleToken) ValidateBasic() sdkTypes.Error {
 		return sdkTypes.ErrUnknownRequest("Cannot have max supply 0 for fixed supply token")
 	}
 
+	if err := validateDecimal(msg.Decimals); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/x/token/fungible/validation.go
+++ b/x/token/fungible/validation.go
@@ -10,9 +10,9 @@ import (
 
 const (
 	// TODO TODO - calculate exactly
-	MetadataMaxLength    = 60
+	MetadataMaxLength    = 256
 	TokenNameMaxLength   = 100
-	TokenSymbolMaxLength = 100
+	TokenSymbolMaxLength = 40
 )
 
 func validateTokenName(tokenName string) sdkTypes.Error {
@@ -57,5 +57,12 @@ func validateAmount(amount string) sdkTypes.Error {
 		return sdkTypes.ErrInvalidCoins(fmt.Sprintf("Invalid amount string: %s", err))
 	}
 
+	return nil
+}
+
+func validateDecimal(decimal int) sdkTypes.Error {
+	if decimal < 0 || decimal > 18 {
+		return sdkTypes.ErrInternal("Invalid decimal")
+	}
 	return nil
 }

--- a/x/token/nonfungible/msgs.go
+++ b/x/token/nonfungible/msgs.go
@@ -81,7 +81,7 @@ func (msg MsgCreateNonFungibleToken) ValidateBasic() sdkTypes.Error {
 	if err := ValidateSymbol(msg.Symbol); err != nil {
 		return err
 	}
-
+	
 	return nil
 }
 

--- a/x/token/nonfungible/validation.go
+++ b/x/token/nonfungible/validation.go
@@ -12,7 +12,7 @@ const (
 	// TODO TODO - calculate exactly
 	MaxLength            = 256
 	TokenNameMaxLength   = 100
-	TokenSymbolMaxLength = 100
+	TokenSymbolMaxLength = 40
 )
 
 func validateTokenName(tokenName string) sdkTypes.Error {


### PR DESCRIPTION
Things changed:
- symbol length change to 40
- added validation for decimal in ft (token decimal not allow to be 0 or greater than 18)
- disable rpc end point for listing token and nonfungible token 