### PR TITLE
include fee calculation for nft base on token action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - disable rpc end point for listing token and nonfungible token 
 - added another rpc for test (AccountCdc)
 - remove cdc from querry account end point (Account)
+- split fee calculation between token (ft and nft)
+- added fee cli for setting ft/ nft multiplier, ft/ nft token fee by token action
+- added error code for checking update endorser(endorser has to be whitelisted)
+- added function for updating nft endorser list
+- update rpc endpoint for debug/fee_info to display nft and ft multiplier
 
 # Version 1.2.1
 - Adding non fungible token module

--- a/app/rpc.go
+++ b/app/rpc.go
@@ -49,15 +49,16 @@ type NonFungibleTokenListInfo struct {
 }
 
 type FeeInfo struct {
-	Authorizers        []sdkTypes.AccAddress
-	Multiplier         string
-	TokenMultiplier    string
-	TokenFeeCollectors []sdkTypes.AccAddress
-	AliasFeeCollectors []sdkTypes.AccAddress
-	FeeSettings        []fee.FeeSetting
-	AccountFeeSettings map[string]string
-	MsgFeeSettings     map[string]string
-	TokenFeeSetting    map[string]string
+	Authorizers                []sdkTypes.AccAddress
+	Multiplier                 string
+	FungibleTokenMultiplier    string
+	NonFungibleTokenMultiplier string
+	TokenFeeCollectors         []sdkTypes.AccAddress
+	AliasFeeCollectors         []sdkTypes.AccAddress
+	FeeSettings                []fee.FeeSetting
+	AccountFeeSettings         map[string]string
+	MsgFeeSettings             map[string]string
+	TokenFeeSetting            map[string]string
 }
 
 type KYCInfo struct {
@@ -245,7 +246,8 @@ func (app *mxwApp) FeeInfo(ctx *rpctypes.Context) (FeeInfo, error) {
 	var i FeeInfo
 	i.Authorizers = app.feeKeeper.GetAuthorisedAddresses(appCtx)
 	i.Multiplier, _ = app.feeKeeper.GetFeeMultiplier(appCtx)
-	i.TokenMultiplier, _ = app.feeKeeper.GetTokenFeeMultiplier(appCtx)
+	i.FungibleTokenMultiplier, _ = app.feeKeeper.GetFungibleTokenFeeMultiplier(appCtx)
+	i.NonFungibleTokenMultiplier, _ = app.feeKeeper.GetNonFungibleTokenFeeMultiplier(appCtx)
 	i.TokenFeeCollectors = app.feeKeeper.GetFeeCollectorAddresses(appCtx, "token")
 	i.AliasFeeCollectors = app.feeKeeper.GetFeeCollectorAddresses(appCtx, "alias")
 	i.FeeSettings = app.feeKeeper.ListAllSysFeeSetting(appCtx)

--- a/tests/fee_test.go
+++ b/tests/fee_test.go
@@ -69,11 +69,13 @@ func makeFeeTxs() []*testCase {
 		{"fee", false, false, "assign zero-fee to mostafa-commit", "nft-fee-auth", "0cin", 0, feeInfo{"assign-acc", "zero", "nft-mostafa", "", "", "", "", "nft-fee-auth"}, "", nil},
 
 		//=============================================start : used by fungible token modules
-		//set fee fore msgTokenMultiplier to fee 0cin
-		{"fee", false, false, "assign msgTokenMultiplier to fee 0cin. commit", "fee-auth", "0cin", 0, feeInfo{"assign-msg", "zero", "fee-updateTokenMultiplier", "", "", "", "", "fee-auth"}, "", nil},
+		//set fee fore msgFungibleTokenMultiplier to fee 0cin
+		{"fee", false, false, "assign msgFungibleTokenMultiplier to fee 0cin. commit", "fee-auth", "0cin", 0, feeInfo{"assign-msg", "zero", "fee-updateFungibleTokenMultiplier", "", "", "", "", "fee-auth"}, "", nil},
+		{"fee", false, false, "assign msgNonFungibleTokenMultiplier to fee 0cin. commit", "fee-auth", "0cin", 0, feeInfo{"assign-msg", "zero", "fee-updateNonFungibleTokenMultiplier", "", "", "", "", "fee-auth"}, "", nil},
 
 		//add token fee multiplier
-		{"fee", false, false, "create token fee multiplier. commit", "fee-auth", "0cin", 0, feeInfo{"token-fee-multiplier", "", "", "1", "", "", "", "fee-auth"}, "", nil},
+		{"fee", false, false, "create fungible token fee multiplier. commit", "fee-auth", "0cin", 0, feeInfo{"fungible-token-fee-multiplier", "", "", "1", "", "", "", "fee-auth"}, "", nil},
+		{"fee", false, false, "create nonFungible token fee multiplier. commit", "fee-auth", "0cin", 0, feeInfo{"nonFungible-token-fee-multiplier", "", "", "1", "", "", "", "fee-auth"}, "", nil},
 	}
 
 	return tcs
@@ -95,8 +97,11 @@ func makeFeeMsg(t *testing.T, function, name, assignee, multiplier, _min, _max, 
 		msg = fee.NewMsgAssignFeeToAcc(name, tKeys[assignee].addr, tKeys[issuer].addr)
 	case "multiplier":
 		msg = fee.NewMsgMultiplier(multiplier, tKeys[issuer].addr)
-	case "token-fee-multiplier":
-		msg = fee.NewMsgTokenMultiplier(multiplier, tKeys[issuer].addr)
+	case "fungible-token-fee-multiplier":
+		msg = fee.NewMsgFungibleTokenMultiplier(multiplier, tKeys[issuer].addr)
+	case "nonFungible-token-fee-multiplier":
+		msg = fee.NewMsgNonFungibleTokenMultiplier(multiplier, tKeys[issuer].addr)
 	}
+
 	return msg
 }

--- a/tests/non_fungible_test.go
+++ b/tests/non_fungible_test.go
@@ -519,6 +519,10 @@ func makeApproveNonFungibleTokenMsg(t *testing.T, signer string, provider string
 			Action:  "acceptOwnership",
 			FeeName: feeSettingName,
 		},
+		{
+			Action:  "endorse",
+			FeeName: feeSettingName,
+		},
 	}
 
 	mintL := sdkTypes.NewUintFromString(mintLimit)

--- a/types/errors.go
+++ b/types/errors.go
@@ -26,6 +26,7 @@ const (
 	CodeTokenInvalidItemOwner              sdkTypes.CodeType = 2108
 	CodeTokenItemNotModifiable             sdkTypes.CodeType = 2109
 	CodeTokenItemNotFound                  sdkTypes.CodeType = 2110
+	CodeUnauthorisedEndorser               sdkTypes.CodeType = 2111
 
 	CodeFeeNotFound             sdkTypes.CodeType = 3001
 	CodeTokenFeeSettingNotFound sdkTypes.CodeType = 3002
@@ -148,4 +149,8 @@ func ErrTokenItemNotModifiable() sdkTypes.Error {
 
 func ErrTokenItemNotFound() sdkTypes.Error {
 	return newErrorWithMXWCodespace(CodeTokenItemNotFound, "Token item not found.")
+}
+
+func ErrUnauthorisedEndorser() sdkTypes.Error {
+	return newErrorWithMXWCodespace(CodeUnauthorisedEndorser, "Endorser is not whitelisted.")
 }

--- a/x/fee/client/cli/query.go
+++ b/x/fee/client/cli/query.go
@@ -61,10 +61,10 @@ func GetMsgFeeSetting(cdc *codec.Codec) *cobra.Command {
 
 }
 
-func GetTokenFeeSetting(cdc *codec.Codec) *cobra.Command {
+func GetFungibleTokenFeeSetting(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "token [token-symbol] [action]",
-		Short: "get fee setting by token symbol and action",
+		Use:   "fungible-token [token-symbol] [action]",
+		Short: "get fee setting by fungible-token symbol and action",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -72,7 +72,33 @@ func GetTokenFeeSetting(cdc *codec.Codec) *cobra.Command {
 			symbol := args[0]
 			action := args[1]
 
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s/%s/%s", "fee", fee.QueryTokenFeeSetting, symbol, action), nil)
+			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s/%s/%s", "fee", fee.QueryFungibleTokenFeeSetting, symbol, action), nil)
+			if err != nil {
+				fmt.Printf("Could not get token fee setting: %s\n", err)
+				return nil
+			}
+
+			fmt.Println(string(res))
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func GetNonFungibleTokenFeeSetting(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "nonFungible-token [token-symbol] [action]",
+		Short: "get fee setting by nonFungible-token symbol and action",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			symbol := args[0]
+			action := args[1]
+
+			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s/%s/%s", "fee", fee.QueryNonFungibleTokenFeeSetting, symbol, action), nil)
 			if err != nil {
 				fmt.Printf("Could not get token fee setting: %s\n", err)
 				return nil
@@ -135,17 +161,40 @@ func GetFeeMultiplier(cdc *codec.Codec) *cobra.Command {
 	return cmd
 }
 
-func GetTokenFeeMultiplier(cdc *codec.Codec) *cobra.Command {
+func GetFungibleTokenFeeMultiplier(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "token-fee-multiplier",
-		Short: "get token fee multiplier",
+		Use:   "fungible-token-fee-multiplier",
+		Short: "get fungible token fee multiplier",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", "fee", fee.QueryTokenFeeMultiplier), nil)
+			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", "fee", fee.QueryFungibleTokenFeeMultiplier), nil)
 			if err != nil {
-				fmt.Printf("Could not get token fee multiplier: %s\n", err)
+				fmt.Printf("Could not get fungible-token fee multiplier: %s\n", err)
+				return nil
+			}
+
+			fmt.Println(string(res))
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func GetNonFungibleTokenFeeMultiplier(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "nonFungible-token-fee-multiplier",
+		Short: "get nonFungible token fee multiplier",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", "fee", fee.QueryNonFungibleTokenFeeMultiplier), nil)
+			if err != nil {
+				fmt.Printf("Could not get nonFungible-token fee multiplier: %s\n", err)
 				return nil
 			}
 

--- a/x/fee/client/module_client.go
+++ b/x/fee/client/module_client.go
@@ -2,9 +2,9 @@ package client
 
 import (
 	"github.com/cosmos/cosmos-sdk/client"
+	feeCmd "github.com/maxonrow/maxonrow-go/x/fee/client/cli"
 	"github.com/spf13/cobra"
 	"github.com/tendermint/go-amino"
-	feeCmd "github.com/maxonrow/maxonrow-go/x/fee/client/cli"
 )
 
 type ModuleClient struct {
@@ -25,9 +25,11 @@ func (mc ModuleClient) GetQueryCmd() *cobra.Command {
 	queryCmd.AddCommand(client.GetCommands(
 		feeCmd.GetSysFeeSetting(mc.cdc),
 		feeCmd.GetMsgFeeSetting(mc.cdc),
-		feeCmd.GetTokenFeeSetting(mc.cdc),
+		feeCmd.GetFungibleTokenFeeSetting(mc.cdc),
+		feeCmd.GetNonFungibleTokenFeeSetting(mc.cdc),
 		feeCmd.GetFeeMultiplier(mc.cdc),
-		feeCmd.GetTokenFeeMultiplier(mc.cdc),
+		feeCmd.GetFungibleTokenFeeMultiplier(mc.cdc),
+		feeCmd.GetNonFungibleTokenFeeMultiplier(mc.cdc),
 		feeCmd.GetAccFeeSetting(mc.cdc),
 	)...)
 
@@ -47,8 +49,10 @@ func (mc ModuleClient) GetTxCmd() *cobra.Command {
 		feeCmd.CreateMsgAssignFeeToMsg(mc.cdc),
 		feeCmd.CreateMsgAssignFeeToAcc(mc.cdc),
 		feeCmd.CreateFeeMultiplier(mc.cdc),
-		feeCmd.CreateTokenFeeMultiplier(mc.cdc),
-		feeCmd.SetTokenFeeSetting(mc.cdc),
+		feeCmd.CreateFungibleTokenFeeMultiplier(mc.cdc),
+		feeCmd.CreateNonFungibleTokenFeeMultiplier(mc.cdc),
+		feeCmd.SetFungibleTokenFeeSetting(mc.cdc),
+		feeCmd.SetNonFungibleTokenFeeSetting(mc.cdc),
 		feeCmd.CreateMsgDeleteAccountFeeSetting(mc.cdc),
 		//feeCmd.AddSysFeeSetting(mc.cdc),
 	)...)

--- a/x/fee/codec.go
+++ b/x/fee/codec.go
@@ -6,9 +6,11 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgSysFeeSetting{}, "fee/sysFeeSetting", nil)
 	cdc.RegisterConcrete(MsgAssignFeeToMsg{}, "fee/assignFeeToMsg", nil)
 	cdc.RegisterConcrete(MsgAssignFeeToAcc{}, "fee/assignFeeToAcc", nil)
-	cdc.RegisterConcrete(MsgAssignFeeToToken{}, "fee/assignFeeToToken", nil)
+	cdc.RegisterConcrete(MsgAssignFeeToFungibleToken{}, "fee/assignFeeToFungibleToken", nil)
+	cdc.RegisterConcrete(MsgAssignFeeToNonFungibleToken{}, "fee/assignFeeToNonFungibleToken", nil)
 	cdc.RegisterConcrete(MsgMultiplier{}, "fee/msgMultiplier", nil)
-	cdc.RegisterConcrete(MsgTokenMultiplier{}, "fee/msgTokenMultiplier", nil)
+	cdc.RegisterConcrete(MsgFungibleTokenMultiplier{}, "fee/msgFungibleTokenMultiplier", nil)
+	cdc.RegisterConcrete(MsgNonFungibleTokenMultiplier{}, "fee/msgNonFungibleTokenMultiplier", nil)
 	cdc.RegisterConcrete(MsgDeleteSysFeeSetting{}, "fee/deleteSysFeeSetting", nil)
 	cdc.RegisterConcrete(MsgDeleteAccFeeSetting{}, "fee/deleteAccFeeSetting", nil)
 }

--- a/x/fee/handler.go
+++ b/x/fee/handler.go
@@ -16,12 +16,16 @@ func NewHandler(keeper *Keeper) sdkTypes.Handler {
 			return handleMsgAssignFeeToMsg(ctx, keeper, msg)
 		case MsgAssignFeeToAcc:
 			return handleMsgAssignFeeToAcc(ctx, keeper, msg)
-		case MsgAssignFeeToToken:
-			return handleMsgAssignFeeToToken(ctx, keeper, msg)
+		case MsgAssignFeeToFungibleToken:
+			return handleMsgAssignFeeToFungibleToken(ctx, keeper, msg)
+		case MsgAssignFeeToNonFungibleToken:
+			return handleMsgAssignFeeToNonFungibleToken(ctx, keeper, msg)
 		case MsgMultiplier:
 			return handleMsgMultiplier(ctx, keeper, msg)
-		case MsgTokenMultiplier:
-			return handleMsgTokenMultiplier(ctx, keeper, msg)
+		case MsgFungibleTokenMultiplier:
+			return handleMsgFungibleTokenMultiplier(ctx, keeper, msg)
+		case MsgNonFungibleTokenMultiplier:
+			return handleMsgNonFungibleTokenMultiplier(ctx, keeper, msg)
 		case MsgDeleteSysFeeSetting:
 			return handleMsgDeleteSysFeeSetting(ctx, keeper, msg)
 		case MsgDeleteAccFeeSetting:
@@ -45,16 +49,24 @@ func handleMsgAssignFeeToAcc(ctx sdkTypes.Context, keeper *Keeper, msg MsgAssign
 	return keeper.AssignFeeToAcc(ctx, msg)
 }
 
-func handleMsgAssignFeeToToken(ctx sdkTypes.Context, keeper *Keeper, msg MsgAssignFeeToToken) sdkTypes.Result {
-	return keeper.AssignFeeToToken(ctx, msg)
+func handleMsgAssignFeeToFungibleToken(ctx sdkTypes.Context, keeper *Keeper, msg MsgAssignFeeToFungibleToken) sdkTypes.Result {
+	return keeper.AssignFeeToFungibleToken(ctx, msg)
+}
+
+func handleMsgAssignFeeToNonFungibleToken(ctx sdkTypes.Context, keeper *Keeper, msg MsgAssignFeeToNonFungibleToken) sdkTypes.Result {
+	return keeper.AssignFeeToNonFungibleToken(ctx, msg)
 }
 
 func handleMsgMultiplier(ctx sdkTypes.Context, keeper *Keeper, msg MsgMultiplier) sdkTypes.Result {
 	return keeper.CreateMultiplier(ctx, msg)
 }
 
-func handleMsgTokenMultiplier(ctx sdkTypes.Context, keeper *Keeper, msg MsgTokenMultiplier) sdkTypes.Result {
-	return keeper.CreateTokenMultiplier(ctx, msg)
+func handleMsgFungibleTokenMultiplier(ctx sdkTypes.Context, keeper *Keeper, msg MsgFungibleTokenMultiplier) sdkTypes.Result {
+	return keeper.CreateFungibleTokenMultiplier(ctx, msg)
+}
+
+func handleMsgNonFungibleTokenMultiplier(ctx sdkTypes.Context, keeper *Keeper, msg MsgNonFungibleTokenMultiplier) sdkTypes.Result {
+	return keeper.CreateNonFungibleTokenMultiplier(ctx, msg)
 }
 
 func handleMsgDeleteSysFeeSetting(ctx sdkTypes.Context, keeper *Keeper, msg MsgDeleteSysFeeSetting) sdkTypes.Result {

--- a/x/fee/keeper.go
+++ b/x/fee/keeper.go
@@ -22,9 +22,9 @@ type FeeSetting struct {
 }
 
 const (
-	TransferFungibleToken  = "transfer"
-	MintFungibleToken      = "mint"
-	BurnFungibleToken      = "burn"
+	TransferToken          = "transfer"
+	MintToken              = "mint"
+	BurnToken              = "burn"
 	TransferTokenOwnership = "transferOwnership"
 	AcceptTokenOwnership   = "acceptOwnership"
 )
@@ -39,7 +39,7 @@ var prefixMultiplier = []byte("0x50")
 var prefixTokenMultiplier = []byte("0x51")
 
 // Token Actions
-var tokenActions = []string{TransferFungibleToken, MintFungibleToken, BurnFungibleToken, TransferTokenOwnership, AcceptTokenOwnership}
+var tokenActions = []string{TransferToken, MintToken, BurnToken, TransferTokenOwnership, AcceptTokenOwnership}
 
 // keys
 func getAuthorisedKey() []byte {

--- a/x/fee/keeper.go
+++ b/x/fee/keeper.go
@@ -27,6 +27,7 @@ const (
 	BurnToken              = "burn"
 	TransferTokenOwnership = "transferOwnership"
 	AcceptTokenOwnership   = "acceptOwnership"
+	Endorse                = "endorse"
 )
 
 var prefixAuthorised = []byte("0x01")
@@ -36,10 +37,12 @@ var prefixMsgFeeSetting = []byte("0x04")
 var prefixAccFeeSetting = []byte("0x05")
 var prefixTokenFeeSetting = []byte("0x06")
 var prefixMultiplier = []byte("0x50")
-var prefixTokenMultiplier = []byte("0x51")
+var prefixFungibleTokenMultiplier = []byte("0x51")
+var prefixNonFungibleTokenMultiplier = []byte("0x52")
 
 // Token Actions
-var tokenActions = []string{TransferToken, MintToken, BurnToken, TransferTokenOwnership, AcceptTokenOwnership}
+var fungibleTokenActions = []string{TransferToken, MintToken, BurnToken, TransferTokenOwnership, AcceptTokenOwnership}
+var nonFungibleTokenActions = []string{TransferToken, MintToken, BurnToken, TransferTokenOwnership, AcceptTokenOwnership, Endorse}
 
 // keys
 func getAuthorisedKey() []byte {
@@ -62,8 +65,13 @@ func getAccFeeSettingKey(acc sdkTypes.AccAddress) []byte {
 	return append(prefixAccFeeSetting, acc.Bytes()...)
 }
 
-func getTokenFeeSettingKey(symbol, action string) []byte {
-	tokenAction := symbol + ":" + action
+func getFungibleTokenFeeSettingKey(symbol, action string) []byte {
+	tokenAction := "ft:" + symbol + ":" + action
+	return append(prefixTokenFeeSetting, []byte(tokenAction)...)
+}
+
+func getNonFungibleTokenFeeSettingKey(symbol, action string) []byte {
+	tokenAction := "nft:" + symbol + ":" + action
 	return append(prefixTokenFeeSetting, []byte(tokenAction)...)
 }
 
@@ -71,8 +79,12 @@ func getFeeMultiplierKey() []byte {
 	return prefixMultiplier
 }
 
-func getTokenFeeMultiplierKey() []byte {
-	return prefixTokenMultiplier
+func getFungibleTokenFeeMultiplierKey() []byte {
+	return prefixFungibleTokenMultiplier
+}
+
+func getNonFungibleTokenFeeMultiplierKey() []byte {
+	return prefixNonFungibleTokenMultiplier
 }
 
 func NewKeeper(cdc *codec.Codec, key sdkTypes.StoreKey) Keeper {
@@ -297,25 +309,47 @@ func (k *Keeper) AssignFeeToAcc(
 	}
 }
 
-func (k *Keeper) AssignFeeToToken(
+func (k *Keeper) AssignFeeToFungibleToken(
 	ctx sdkTypes.Context,
-	msgAssignFeeToToken MsgAssignFeeToToken,
+	msgAssignFeeToFungibleToken MsgAssignFeeToFungibleToken,
 ) sdkTypes.Result {
 
-	if !k.IsAuthorised(ctx, msgAssignFeeToToken.Issuer) {
+	if !k.IsAuthorised(ctx, msgAssignFeeToFungibleToken.Issuer) {
 		return sdkTypes.ErrUnknownRequest("Not authorised to create msg fee setting.").Result()
 	}
 
-	err := k.AssignFeeToTokenAction(ctx, msgAssignFeeToToken.FeeName, msgAssignFeeToToken.Symbol, msgAssignFeeToToken.Action)
+	err := k.AssignFeeToFungibleTokenAction(ctx, msgAssignFeeToFungibleToken.FeeName, msgAssignFeeToFungibleToken.Symbol, msgAssignFeeToFungibleToken.Action)
 	if err != nil {
 		return err.Result()
 	}
 
-	eventParam := []string{msgAssignFeeToToken.GetSigners()[0].String(), msgAssignFeeToToken.Symbol}
-	eventSignature := "CreatedTokenFeeSetting(string,string)"
+	eventParam := []string{msgAssignFeeToFungibleToken.GetSigners()[0].String(), msgAssignFeeToFungibleToken.Symbol}
+	eventSignature := "CreatedFungibleTokenFeeSetting(string,string)"
 
 	return sdkTypes.Result{
-		Events: types.MakeMxwEvents(eventSignature, msgAssignFeeToToken.GetSigners()[0].String(), eventParam),
+		Events: types.MakeMxwEvents(eventSignature, msgAssignFeeToFungibleToken.GetSigners()[0].String(), eventParam),
+	}
+}
+
+func (k *Keeper) AssignFeeToNonFungibleToken(
+	ctx sdkTypes.Context,
+	msgAssignFeeToNonFungibleToken MsgAssignFeeToNonFungibleToken,
+) sdkTypes.Result {
+
+	if !k.IsAuthorised(ctx, msgAssignFeeToNonFungibleToken.Issuer) {
+		return sdkTypes.ErrUnknownRequest("Not authorised to create msg fee setting.").Result()
+	}
+
+	err := k.AssignFeeToNonFungibleTokenAction(ctx, msgAssignFeeToNonFungibleToken.FeeName, msgAssignFeeToNonFungibleToken.Symbol, msgAssignFeeToNonFungibleToken.Action)
+	if err != nil {
+		return err.Result()
+	}
+
+	eventParam := []string{msgAssignFeeToNonFungibleToken.GetSigners()[0].String(), msgAssignFeeToNonFungibleToken.Symbol}
+	eventSignature := "CreatedFungibleTokenFeeSetting(string,string)"
+
+	return sdkTypes.Result{
+		Events: types.MakeMxwEvents(eventSignature, msgAssignFeeToNonFungibleToken.GetSigners()[0].String(), eventParam),
 	}
 }
 
@@ -338,22 +372,41 @@ func (k *Keeper) CreateMultiplier(
 	}
 }
 
-func (k *Keeper) CreateTokenMultiplier(
+func (k *Keeper) CreateFungibleTokenMultiplier(
 	ctx sdkTypes.Context,
-	msgTokenMultiplier MsgTokenMultiplier,
+	msgTokenMultiplier MsgFungibleTokenMultiplier,
 ) sdkTypes.Result {
 
 	if !k.IsAuthorised(ctx, msgTokenMultiplier.Issuer) {
 		return sdkTypes.ErrUnknownRequest("Not authorised to create msg fee setting.").Result()
 	}
 
-	k.storeTokenFeeMultiplier(ctx, msgTokenMultiplier.Multiplier)
+	k.storeFungibleTokenFeeMultiplier(ctx, msgTokenMultiplier.FtMultiplier)
 
 	eventParam := []string{msgTokenMultiplier.GetSigners()[0].String()}
-	eventSignature := "CreatedTokenFeeMultiplier(string)"
+	eventSignature := "CreatedFungibleTokenFeeMultiplier(string)"
 
 	return sdkTypes.Result{
 		Events: types.MakeMxwEvents(eventSignature, msgTokenMultiplier.GetSigners()[0].String(), eventParam),
+	}
+}
+
+func (k *Keeper) CreateNonFungibleTokenMultiplier(
+	ctx sdkTypes.Context,
+	msgNonFungibleTokenMultiplier MsgNonFungibleTokenMultiplier,
+) sdkTypes.Result {
+
+	if !k.IsAuthorised(ctx, msgNonFungibleTokenMultiplier.Issuer) {
+		return sdkTypes.ErrUnknownRequest("Not authorised to create msg fee setting.").Result()
+	}
+
+	k.storeNonFungibleTokenFeeMultiplier(ctx, msgNonFungibleTokenMultiplier.NftMultiplier)
+
+	eventParam := []string{msgNonFungibleTokenMultiplier.GetSigners()[0].String()}
+	eventSignature := "CreatedNonFungibleTokenFeeMultiplier(string)"
+
+	return sdkTypes.Result{
+		Events: types.MakeMxwEvents(eventSignature, msgNonFungibleTokenMultiplier.GetSigners()[0].String(), eventParam),
 	}
 }
 
@@ -371,18 +424,36 @@ func (k *Keeper) assignFeeToAcc(ctx sdkTypes.Context, msg MsgAssignFeeToAcc) {
 	store.Set(key, []byte(msg.FeeName))
 }
 
-func (k *Keeper) AssignFeeToTokenAction(ctx sdkTypes.Context, feeName, symbol, action string) sdkTypes.Error {
+func (k *Keeper) AssignFeeToFungibleTokenAction(ctx sdkTypes.Context, feeName, symbol, action string) sdkTypes.Error {
 	if !k.FeeSettingExists(ctx, feeName) {
 		return types.ErrFeeSettingNotExists(feeName)
 	}
 
-	ok := ContainAction(action)
+	ok := ContainFungibleAction(action)
 	if !ok {
 		return sdkTypes.ErrUnknownRequest("Token action is not recognize.")
 	}
 
 	store := ctx.KVStore(k.key)
-	key := getTokenFeeSettingKey(symbol, action)
+	key := getFungibleTokenFeeSettingKey(symbol, action)
+
+	store.Set(key, []byte(feeName))
+
+	return nil
+}
+
+func (k *Keeper) AssignFeeToNonFungibleTokenAction(ctx sdkTypes.Context, feeName, symbol, action string) sdkTypes.Error {
+	if !k.FeeSettingExists(ctx, feeName) {
+		return types.ErrFeeSettingNotExists(feeName)
+	}
+
+	ok := ContainNonFungibleAction(action)
+	if !ok {
+		return sdkTypes.ErrUnknownRequest("Token action is not recognize.")
+	}
+
+	store := ctx.KVStore(k.key)
+	key := getNonFungibleTokenFeeSettingKey(symbol, action)
 
 	store.Set(key, []byte(feeName))
 
@@ -397,10 +468,18 @@ func (k *Keeper) storeFeeMultiplier(ctx sdkTypes.Context, multiplier string) {
 	store.Set(keyMsgMultiplier, []byte(multiplier))
 }
 
-// Token Fee multiplier
-func (k *Keeper) storeTokenFeeMultiplier(ctx sdkTypes.Context, multiplier string) {
+//Fungible Token Fee multiplier
+func (k *Keeper) storeFungibleTokenFeeMultiplier(ctx sdkTypes.Context, multiplier string) {
 	store := ctx.KVStore(k.key)
-	keyMsgTokenMultiplier := getTokenFeeMultiplierKey()
+	keyMsgTokenMultiplier := getFungibleTokenFeeMultiplierKey()
+
+	store.Set(keyMsgTokenMultiplier, []byte(multiplier))
+}
+
+//NonFungible Token Fee multiplier
+func (k *Keeper) storeNonFungibleTokenFeeMultiplier(ctx sdkTypes.Context, multiplier string) {
+	store := ctx.KVStore(k.key)
+	keyMsgTokenMultiplier := getNonFungibleTokenFeeMultiplierKey()
 
 	store.Set(keyMsgTokenMultiplier, []byte(multiplier))
 }
@@ -439,10 +518,27 @@ func (k *Keeper) GetAccFeeSetting(ctx sdkTypes.Context, acc sdkTypes.AccAddress)
 	return nil, nil
 }
 
-func (k *Keeper) GetTokenFeeSetting(ctx sdkTypes.Context, tokenSymbol, action string) (*FeeSetting, sdkTypes.Error) {
+func (k *Keeper) GetFungibleTokenFeeSetting(ctx sdkTypes.Context, tokenSymbol, action string) (*FeeSetting, sdkTypes.Error) {
 	store := ctx.KVStore(k.key)
 
-	keyTokenFeeSetting := getTokenFeeSettingKey(tokenSymbol, action)
+	keyTokenFeeSetting := getFungibleTokenFeeSettingKey(tokenSymbol, action)
+	feeName := store.Get(keyTokenFeeSetting)
+	if feeName == nil {
+		return nil, types.ErrTokenFeeSettingNotExists(tokenSymbol)
+	}
+
+	feeSetting, err := k.GetFeeSettingByName(ctx, string(feeName))
+	if err != nil {
+		return nil, err
+	}
+
+	return feeSetting, nil
+}
+
+func (k *Keeper) GetNonFungibleTokenFeeSetting(ctx sdkTypes.Context, tokenSymbol, action string) (*FeeSetting, sdkTypes.Error) {
+	store := ctx.KVStore(k.key)
+
+	keyTokenFeeSetting := getNonFungibleTokenFeeSettingKey(tokenSymbol, action)
 	feeName := store.Get(keyTokenFeeSetting)
 	if feeName == nil {
 		return nil, types.ErrTokenFeeSettingNotExists(tokenSymbol)
@@ -469,10 +565,23 @@ func (k *Keeper) GetFeeMultiplier(ctx sdkTypes.Context) (string, sdkTypes.Error)
 	return string(multiplier), nil
 }
 
-func (k *Keeper) GetTokenFeeMultiplier(ctx sdkTypes.Context) (string, sdkTypes.Error) {
+func (k *Keeper) GetFungibleTokenFeeMultiplier(ctx sdkTypes.Context) (string, sdkTypes.Error) {
 
 	store := ctx.KVStore(k.key)
-	key := getTokenFeeMultiplierKey()
+	key := getFungibleTokenFeeMultiplierKey()
+	multiplier := store.Get(key)
+
+	if multiplier == nil {
+		return string(multiplier), sdkTypes.ErrUnknownRequest(fmt.Sprintf("No token fee multiplier found"))
+	}
+
+	return string(multiplier), nil
+}
+
+func (k *Keeper) GetNonFungibleTokenFeeMultiplier(ctx sdkTypes.Context) (string, sdkTypes.Error) {
+
+	store := ctx.KVStore(k.key)
+	key := getNonFungibleTokenFeeMultiplierKey()
 	multiplier := store.Get(key)
 
 	if multiplier == nil {
@@ -635,8 +744,17 @@ func (k *Keeper) IsFeeSettingUsed(ctx sdkTypes.Context, feeName string) bool {
 	return false
 }
 
-func ContainAction(tokenAction string) bool {
-	for _, action := range tokenActions {
+func ContainFungibleAction(tokenAction string) bool {
+	for _, action := range fungibleTokenActions {
+		if tokenAction == action {
+			return true
+		}
+	}
+	return false
+}
+
+func ContainNonFungibleAction(tokenAction string) bool {
+	for _, action := range nonFungibleTokenActions {
 		if tokenAction == action {
 			return true
 		}

--- a/x/fee/msgs.go
+++ b/x/fee/msgs.go
@@ -279,31 +279,31 @@ func (msg MsgMultiplier) GetSigners() []sdkTypes.AccAddress {
 	return []sdkTypes.AccAddress{msg.Issuer}
 }
 
-// MsgTokenMultiplier create/update token fee multiplier
-type MsgTokenMultiplier struct {
-	Multiplier string              `json:"multiplier"`
-	Issuer     sdkTypes.AccAddress `json:"issuer"`
+// MsgFungibleTokenMultiplier create/update fungible token fee multiplier
+type MsgFungibleTokenMultiplier struct {
+	FtMultiplier string              `json:"ftMultiplier"`
+	Issuer       sdkTypes.AccAddress `json:"issuer"`
 }
 
-func NewMsgTokenMultiplier(multiplier string, issuer sdkTypes.AccAddress) MsgTokenMultiplier {
-	return MsgTokenMultiplier{
-		Multiplier: multiplier,
-		Issuer:     issuer,
+func NewMsgFungibleTokenMultiplier(multiplier string, issuer sdkTypes.AccAddress) MsgFungibleTokenMultiplier {
+	return MsgFungibleTokenMultiplier{
+		FtMultiplier: multiplier,
+		Issuer:       issuer,
 	}
 }
 
-func (msg MsgTokenMultiplier) Route() string {
+func (msg MsgFungibleTokenMultiplier) Route() string {
 	return routeName
 }
 
-func (msg MsgTokenMultiplier) Type() string {
-	return "updateTokenMultiplier"
+func (msg MsgFungibleTokenMultiplier) Type() string {
+	return "updateFungibleTokenMultiplier"
 }
 
-func (msg MsgTokenMultiplier) ValidateBasic() sdkTypes.Error {
+func (msg MsgFungibleTokenMultiplier) ValidateBasic() sdkTypes.Error {
 
 	minMultiplier, _ := sdkTypes.NewDecFromStr("0")
-	multiplier, err := sdkTypes.NewDecFromStr(msg.Multiplier)
+	multiplier, err := sdkTypes.NewDecFromStr(msg.FtMultiplier)
 	if err != nil {
 		return err
 	}
@@ -312,7 +312,7 @@ func (msg MsgTokenMultiplier) ValidateBasic() sdkTypes.Error {
 		return sdkTypes.ErrInvalidAddress(msg.Issuer.String())
 	}
 
-	if len(msg.Multiplier) <= 0 {
+	if len(msg.FtMultiplier) <= 0 {
 		return sdkTypes.ErrInvalidCoins("Multiplier cant be empty.")
 	}
 
@@ -323,23 +323,75 @@ func (msg MsgTokenMultiplier) ValidateBasic() sdkTypes.Error {
 	return nil
 }
 
-func (msg MsgTokenMultiplier) GetSignBytes() []byte {
+func (msg MsgFungibleTokenMultiplier) GetSignBytes() []byte {
 	return sdkTypes.MustSortJSON(msgCdc.MustMarshalJSON(msg))
 }
 
-func (msg MsgTokenMultiplier) GetSigners() []sdkTypes.AccAddress {
+func (msg MsgFungibleTokenMultiplier) GetSigners() []sdkTypes.AccAddress {
 	return []sdkTypes.AccAddress{msg.Issuer}
 }
 
-type MsgAssignFeeToToken struct {
+// MsgNonFungibleTokenMultiplier create/update nonFungible token fee multiplier
+type MsgNonFungibleTokenMultiplier struct {
+	NftMultiplier string              `json:"nftMultiplier"`
+	Issuer        sdkTypes.AccAddress `json:"issuer"`
+}
+
+func NewMsgNonFungibleTokenMultiplier(multiplier string, issuer sdkTypes.AccAddress) MsgNonFungibleTokenMultiplier {
+	return MsgNonFungibleTokenMultiplier{
+		NftMultiplier: multiplier,
+		Issuer:        issuer,
+	}
+}
+
+func (msg MsgNonFungibleTokenMultiplier) Route() string {
+	return routeName
+}
+
+func (msg MsgNonFungibleTokenMultiplier) Type() string {
+	return "updateNonFungibleTokenMultiplier"
+}
+
+func (msg MsgNonFungibleTokenMultiplier) ValidateBasic() sdkTypes.Error {
+
+	minMultiplier, _ := sdkTypes.NewDecFromStr("0")
+	multiplier, err := sdkTypes.NewDecFromStr(msg.NftMultiplier)
+	if err != nil {
+		return err
+	}
+
+	if msg.Issuer.Empty() {
+		return sdkTypes.ErrInvalidAddress(msg.Issuer.String())
+	}
+
+	if len(msg.NftMultiplier) <= 0 {
+		return sdkTypes.ErrInvalidCoins("Multiplier cant be empty.")
+	}
+
+	if !multiplier.GT(minMultiplier) {
+		return sdkTypes.ErrInternal("Multiplier invalid.")
+	}
+
+	return nil
+}
+
+func (msg MsgNonFungibleTokenMultiplier) GetSignBytes() []byte {
+	return sdkTypes.MustSortJSON(msgCdc.MustMarshalJSON(msg))
+}
+
+func (msg MsgNonFungibleTokenMultiplier) GetSigners() []sdkTypes.AccAddress {
+	return []sdkTypes.AccAddress{msg.Issuer}
+}
+
+type MsgAssignFeeToFungibleToken struct {
 	FeeName string              `json:"fee_name"`
 	Symbol  string              `json:"symbol"`
 	Action  string              `json:"action"`
 	Issuer  sdkTypes.AccAddress `json:"issuer"`
 }
 
-func NewMsgAssignFeeToToken(name, symbol, action string, issuer sdkTypes.AccAddress) MsgAssignFeeToToken {
-	return MsgAssignFeeToToken{
+func NewMsgAssignFeeToFungibleToken(name, symbol, action string, issuer sdkTypes.AccAddress) MsgAssignFeeToFungibleToken {
+	return MsgAssignFeeToFungibleToken{
 		FeeName: name,
 		Symbol:  symbol,
 		Action:  action,
@@ -347,15 +399,15 @@ func NewMsgAssignFeeToToken(name, symbol, action string, issuer sdkTypes.AccAddr
 	}
 }
 
-func (msg MsgAssignFeeToToken) Route() string {
+func (msg MsgAssignFeeToFungibleToken) Route() string {
 	return routeName
 }
 
-func (msg MsgAssignFeeToToken) Type() string {
-	return "assignFeeToToken"
+func (msg MsgAssignFeeToFungibleToken) Type() string {
+	return "assignFeeToFungibleToken"
 }
 
-func (msg MsgAssignFeeToToken) ValidateBasic() sdkTypes.Error {
+func (msg MsgAssignFeeToFungibleToken) ValidateBasic() sdkTypes.Error {
 	if msg.Issuer.Empty() {
 		return sdkTypes.ErrInvalidAddress(msg.Issuer.String())
 	}
@@ -375,10 +427,62 @@ func (msg MsgAssignFeeToToken) ValidateBasic() sdkTypes.Error {
 	return nil
 }
 
-func (msg MsgAssignFeeToToken) GetSignBytes() []byte {
+func (msg MsgAssignFeeToFungibleToken) GetSignBytes() []byte {
 	return sdkTypes.MustSortJSON(msgCdc.MustMarshalJSON(msg))
 }
 
-func (msg MsgAssignFeeToToken) GetSigners() []sdkTypes.AccAddress {
+func (msg MsgAssignFeeToFungibleToken) GetSigners() []sdkTypes.AccAddress {
+	return []sdkTypes.AccAddress{msg.Issuer}
+}
+
+type MsgAssignFeeToNonFungibleToken struct {
+	FeeName string              `json:"fee_name"`
+	Symbol  string              `json:"symbol"`
+	Action  string              `json:"action"`
+	Issuer  sdkTypes.AccAddress `json:"issuer"`
+}
+
+func NewMsgAssignFeeToNonFungibleToken(name, symbol, action string, issuer sdkTypes.AccAddress) MsgAssignFeeToNonFungibleToken {
+	return MsgAssignFeeToNonFungibleToken{
+		FeeName: name,
+		Symbol:  symbol,
+		Action:  action,
+		Issuer:  issuer,
+	}
+}
+
+func (msg MsgAssignFeeToNonFungibleToken) Route() string {
+	return routeName
+}
+
+func (msg MsgAssignFeeToNonFungibleToken) Type() string {
+	return "assignFeeToNonFungibleToken"
+}
+
+func (msg MsgAssignFeeToNonFungibleToken) ValidateBasic() sdkTypes.Error {
+	if msg.Issuer.Empty() {
+		return sdkTypes.ErrInvalidAddress(msg.Issuer.String())
+	}
+
+	if len(msg.FeeName) <= 0 {
+		return sdkTypes.ErrInvalidCoins("Fee name type cant be empty.")
+	}
+
+	if len(msg.Symbol) <= 0 {
+		return sdkTypes.ErrInvalidCoins("Symbol cant be empty.")
+	}
+
+	if len(msg.Action) <= 0 {
+		return sdkTypes.ErrInvalidCoins("Action cant be empty.")
+	}
+
+	return nil
+}
+
+func (msg MsgAssignFeeToNonFungibleToken) GetSignBytes() []byte {
+	return sdkTypes.MustSortJSON(msgCdc.MustMarshalJSON(msg))
+}
+
+func (msg MsgAssignFeeToNonFungibleToken) GetSigners() []sdkTypes.AccAddress {
 	return []sdkTypes.AccAddress{msg.Issuer}
 }

--- a/x/fee/querier.go
+++ b/x/fee/querier.go
@@ -11,16 +11,19 @@ import (
 )
 
 const (
-	QuerySysFeeSetting      = "get_sys_fee_setting"
-	QueryMsgFeeSetting      = "get_msg_fee_setting"
-	QueryAccFeeSetting      = "get_acc_fee_setting"
-	QueryTokenFeeSetting    = "get_token_fee_setting"
-	QueryFeeMultiplier      = "get_fee_multiplier"
-	QueryTokenFeeMultiplier = "get_token_fee_multiplier"
-	QueryListFeeSettings    = "list_all_fee_settings"
-	QueryIsFeeSettingExist  = "is_fee_setting_exist"
-	QueryIsFeeSettingInUsed = "is_fee_setting_in_used"
-	QueryIsTokenActionValid = "is_token_action_valid"
+	QuerySysFeeSetting                 = "get_sys_fee_setting"
+	QueryMsgFeeSetting                 = "get_msg_fee_setting"
+	QueryAccFeeSetting                 = "get_acc_fee_setting"
+	QueryFungibleTokenFeeSetting       = "get_fungible_token_fee_setting"
+	QueryNonFungibleTokenFeeSetting    = "get_nonFungible_token_fee_setting"
+	QueryFeeMultiplier                 = "get_fee_multiplier"
+	QueryFungibleTokenFeeMultiplier    = "get_fungible_token_fee_multiplier"
+	QueryNonFungibleTokenFeeMultiplier = "get_nonFungible_token_fee_multiplier"
+	QueryListFeeSettings               = "list_all_fee_settings"
+	QueryIsFeeSettingExist             = "is_fee_setting_exist"
+	QueryIsFeeSettingInUsed            = "is_fee_setting_in_used"
+	QueryIsFungibleTokenActionValid    = "is_fungible_token_action_valid"
+	QueryIsNonFungibleTokenActionValid = "is_nonFungible_token_action_valid"
 )
 
 func NewQuerier(cdc *codec.Codec, keeper *Keeper) sdkTypes.Querier {
@@ -32,20 +35,26 @@ func NewQuerier(cdc *codec.Codec, keeper *Keeper) sdkTypes.Querier {
 			return queryMsgFeeSetting(cdc, ctx, path[1:], req, keeper)
 		case QueryAccFeeSetting:
 			return queryAccFeeSetting(cdc, ctx, path[1:], req, keeper)
-		case QueryTokenFeeSetting:
-			return queryTokenFeeSetting(cdc, ctx, path[1:], req, keeper)
+		case QueryFungibleTokenFeeSetting:
+			return queryFungibleTokenFeeSetting(cdc, ctx, path[1:], req, keeper)
+		case QueryNonFungibleTokenFeeSetting:
+			return queryNonFungibleTokenFeeSetting(cdc, ctx, path[1:], req, keeper)
 		case QueryFeeMultiplier:
 			return queryFeeMultiplier(cdc, ctx, path[1:], req, keeper)
-		case QueryTokenFeeMultiplier:
-			return queryTokenFeeMultiplier(cdc, ctx, path[1:], req, keeper)
+		case QueryFungibleTokenFeeMultiplier:
+			return queryFungibleTokenFeeMultiplier(cdc, ctx, path[1:], req, keeper)
+		case QueryNonFungibleTokenFeeMultiplier:
+			return queryNonFungibleTokenFeeMultiplier(cdc, ctx, path[1:], req, keeper)
 		case QueryListFeeSettings:
 			return queryListFeeSettings(cdc, ctx, path[1:], req, keeper)
 		case QueryIsFeeSettingExist:
 			return queryIsFeeSettingExist(cdc, ctx, path[1:], req, keeper)
 		case QueryIsFeeSettingInUsed:
 			return queryIsFeeSettingInUsed(cdc, ctx, path[1:], req, keeper)
-		case QueryIsTokenActionValid:
-			return queryIsTokenActionValid(cdc, ctx, path[1:], req, keeper)
+		case QueryIsFungibleTokenActionValid:
+			return queryIsFungibleTokenActionValid(cdc, ctx, path[1:], req, keeper)
+		case QueryIsNonFungibleTokenActionValid:
+			return queryIsNonFungibleTokenActionValid(cdc, ctx, path[1:], req, keeper)
 		default:
 			return nil, sdkTypes.ErrUnknownRequest("unknown fee query endpoint")
 		}
@@ -131,18 +140,29 @@ func queryAccFeeSetting(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _
 	return respData, nil
 }
 
-func queryIsTokenActionValid(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _ abci.RequestQuery, keeper *Keeper) ([]byte, sdkTypes.Error) {
+func queryIsFungibleTokenActionValid(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _ abci.RequestQuery, keeper *Keeper) ([]byte, sdkTypes.Error) {
 	if len(path) != 1 {
 		return nil, sdkTypes.ErrUnknownRequest(fmt.Sprintf("Invalid path %s", strings.Join(path, "/")))
 	}
 
 	tokenAction := path[0]
-	isValid := ContainAction(tokenAction)
+	isValid := ContainFungibleAction(tokenAction)
 	str := strconv.FormatBool(isValid)
 	return []byte(str), nil
 }
 
-func queryTokenFeeSetting(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _ abci.RequestQuery, keeper *Keeper) ([]byte, sdkTypes.Error) {
+func queryIsNonFungibleTokenActionValid(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _ abci.RequestQuery, keeper *Keeper) ([]byte, sdkTypes.Error) {
+	if len(path) != 1 {
+		return nil, sdkTypes.ErrUnknownRequest(fmt.Sprintf("Invalid path %s", strings.Join(path, "/")))
+	}
+
+	tokenAction := path[0]
+	isValid := ContainNonFungibleAction(tokenAction)
+	str := strconv.FormatBool(isValid)
+	return []byte(str), nil
+}
+
+func queryFungibleTokenFeeSetting(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _ abci.RequestQuery, keeper *Keeper) ([]byte, sdkTypes.Error) {
 	if len(path) != 2 {
 		return nil, sdkTypes.ErrUnknownRequest(fmt.Sprintf("Invalid path %s", strings.Join(path, "/")))
 	}
@@ -150,7 +170,25 @@ func queryTokenFeeSetting(cdc *codec.Codec, ctx sdkTypes.Context, path []string,
 	tokenSymbol := path[0]
 	tokenAction := path[1]
 
-	feeSetting, err := keeper.GetTokenFeeSetting(ctx, tokenSymbol, tokenAction)
+	feeSetting, err := keeper.GetFungibleTokenFeeSetting(ctx, tokenSymbol, tokenAction)
+	if err != nil {
+		return nil, err
+	}
+
+	respData := cdc.MustMarshalJSON(feeSetting)
+
+	return respData, nil
+}
+
+func queryNonFungibleTokenFeeSetting(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _ abci.RequestQuery, keeper *Keeper) ([]byte, sdkTypes.Error) {
+	if len(path) != 2 {
+		return nil, sdkTypes.ErrUnknownRequest(fmt.Sprintf("Invalid path %s", strings.Join(path, "/")))
+	}
+
+	tokenSymbol := path[0]
+	tokenAction := path[1]
+
+	feeSetting, err := keeper.GetNonFungibleTokenFeeSetting(ctx, tokenSymbol, tokenAction)
 	if err != nil {
 		return nil, err
 	}
@@ -173,12 +211,25 @@ func queryFeeMultiplier(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _
 	return []byte(multiplier), nil
 }
 
-func queryTokenFeeMultiplier(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _ abci.RequestQuery, keeper *Keeper) ([]byte, sdkTypes.Error) {
+func queryFungibleTokenFeeMultiplier(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _ abci.RequestQuery, keeper *Keeper) ([]byte, sdkTypes.Error) {
 	if len(path) != 0 {
 		return nil, sdkTypes.ErrUnknownRequest(fmt.Sprintf("Invalid path %s", strings.Join(path, "/")))
 	}
 
-	tokenFeemultiplier, err := keeper.GetTokenFeeMultiplier(ctx)
+	tokenFeemultiplier, err := keeper.GetFungibleTokenFeeMultiplier(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(tokenFeemultiplier), nil
+}
+
+func queryNonFungibleTokenFeeMultiplier(cdc *codec.Codec, ctx sdkTypes.Context, path []string, _ abci.RequestQuery, keeper *Keeper) ([]byte, sdkTypes.Error) {
+	if len(path) != 0 {
+		return nil, sdkTypes.ErrUnknownRequest(fmt.Sprintf("Invalid path %s", strings.Join(path, "/")))
+	}
+
+	tokenFeemultiplier, err := keeper.GetNonFungibleTokenFeeMultiplier(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/x/token/fungible/keeper.go
+++ b/x/token/fungible/keeper.go
@@ -336,7 +336,7 @@ func (k *Keeper) approveFungibleToken(ctx sdkTypes.Context, symbol string, token
 		if !k.feeKeeper.FeeSettingExists(ctx, tokenFee.FeeName) {
 			return types.ErrFeeSettingNotExists(tokenFee.FeeName).Result()
 		}
-		err := k.feeKeeper.AssignFeeToTokenAction(ctx, tokenFee.FeeName, token.Symbol, tokenFee.Action)
+		err := k.feeKeeper.AssignFeeToFungibleTokenAction(ctx, tokenFee.FeeName, token.Symbol, tokenFee.Action)
 		if err != nil {
 			return err.Result()
 		}

--- a/x/token/nonfungible/codec.go
+++ b/x/token/nonfungible/codec.go
@@ -14,6 +14,7 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgEndorsement{}, "nonFungible/"+MsgTypeEndorsement, nil)
 	cdc.RegisterConcrete(MsgUpdateItemMetadata{}, "nonFungible/"+MsgTypeUpdateItemMetadata, nil)
 	cdc.RegisterConcrete(MsgUpdateNFTMetadata{}, "nonFungible/"+MsgTypeUpdateNFTMetadata, nil)
+	cdc.RegisterConcrete(MsgUpdateEndorserList{}, "nonFungible/"+MsgTypeUpdateEndorserList, nil)
 }
 
 var msgCdc = codec.New()

--- a/x/token/nonfungible/handler.go
+++ b/x/token/nonfungible/handler.go
@@ -43,6 +43,8 @@ func NewHandler(keeper *Keeper) sdkTypes.Handler {
 			return handleMsgUpdateItemMetadata(ctx, keeper, msg)
 		case MsgUpdateNFTMetadata:
 			return handleMsgUpdateNFTMetadata(ctx, keeper, msg)
+		case MsgUpdateEndorserList:
+			return handleMsgUpdateEndorserList(ctx, keeper, msg)
 		default:
 			errMsg := fmt.Sprintf("Unrecognized fungible token Msg type: %v", msg.Type())
 			return sdkTypes.ErrUnknownRequest(errMsg).Result()
@@ -139,4 +141,8 @@ func handleMsgUpdateItemMetadata(ctx sdkTypes.Context, keeper *Keeper, msg MsgUp
 
 func handleMsgUpdateNFTMetadata(ctx sdkTypes.Context, keeper *Keeper, msg MsgUpdateNFTMetadata) sdkTypes.Result {
 	return keeper.UpdateNFTMetadata(ctx, msg.Symbol, msg.From, msg.Metadata)
+}
+
+func handleMsgUpdateEndorserList(ctx sdkTypes.Context, keeper *Keeper, msg MsgUpdateEndorserList) sdkTypes.Result {
+	return keeper.UpdateNFTEndorserList(ctx, msg.Symbol, msg.From, msg.Endorsers)
 }

--- a/x/token/nonfungible/keeper.go
+++ b/x/token/nonfungible/keeper.go
@@ -330,7 +330,7 @@ func (k *Keeper) approveNonFungibleToken(ctx sdkTypes.Context, symbol string, to
 		if !k.feeKeeper.FeeSettingExists(ctx, tokenFee.FeeName) {
 			return types.ErrFeeSettingNotExists(tokenFee.FeeName).Result()
 		}
-		err := k.feeKeeper.AssignFeeToTokenAction(ctx, tokenFee.FeeName, token.Symbol, tokenFee.Action)
+		err := k.feeKeeper.AssignFeeToNonFungibleTokenAction(ctx, tokenFee.FeeName, token.Symbol, tokenFee.Action)
 		if err != nil {
 			return err.Result()
 		}

--- a/x/token/nonfungible/msgs.go
+++ b/x/token/nonfungible/msgs.go
@@ -18,6 +18,7 @@ const (
 	MsgTypeEndorsement                       = "endorsement"
 	MsgTypeUpdateItemMetadata                = "updateItemMetadata"
 	MsgTypeUpdateNFTMetadata                 = "updateNFTMetadata"
+	MsgTypeUpdateEndorserList                = "updateEndorserList"
 )
 
 // MsgCreateNonFungibleToken
@@ -81,7 +82,7 @@ func (msg MsgCreateNonFungibleToken) ValidateBasic() sdkTypes.Error {
 	if err := ValidateSymbol(msg.Symbol); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 
@@ -674,6 +675,52 @@ func (msg MsgUpdateNFTMetadata) GetSignBytes() []byte {
 }
 
 func (msg MsgUpdateNFTMetadata) GetSigners() []sdkTypes.AccAddress {
+	return []sdkTypes.AccAddress{msg.From}
+}
+
+type MsgUpdateEndorserList struct {
+	Symbol    string                `json:"symbol"`
+	From      sdkTypes.AccAddress   `json:"from"`
+	Endorsers []sdkTypes.AccAddress `json:"endorsers"`
+}
+
+func NewMsgUpdateEndorserList(symbol string, from sdkTypes.AccAddress, endorsers []sdkTypes.AccAddress) *MsgUpdateEndorserList {
+	return &MsgUpdateEndorserList{
+		Symbol:    symbol,
+		From:      from,
+		Endorsers: endorsers,
+	}
+}
+
+func (msg MsgUpdateEndorserList) Route() string {
+	return MsgRoute
+}
+
+func (msg MsgUpdateEndorserList) Type() string {
+	return MsgTypeUpdateEndorserList
+}
+
+func (msg MsgUpdateEndorserList) ValidateBasic() sdkTypes.Error {
+	if msg.From.Empty() {
+		return sdkTypes.ErrInvalidAddress(msg.From.String())
+	}
+
+	if err := ValidateSymbol(msg.Symbol); err != nil {
+		return err
+	}
+
+	if len(msg.Endorsers) <= 0 {
+		return sdkTypes.ErrInternal("Endorsers cannot be empty.")
+	}
+
+	return nil
+}
+
+func (msg MsgUpdateEndorserList) GetSignBytes() []byte {
+	return sdkTypes.MustSortJSON(msgCdc.MustMarshalJSON(msg))
+}
+
+func (msg MsgUpdateEndorserList) GetSigners() []sdkTypes.AccAddress {
 	return []sdkTypes.AccAddress{msg.From}
 }
 


### PR DESCRIPTION
- split fee calculation between token (ft and nft)
- added fee cli for setting ft/ nft multiplier, ft/ nft token fee by token action
- added error code for checking update endorser(endorser has to be whitelisted)
- added function for updating nft endorser list
- update rpc endpoint for debug/fee_info to display nft and ft multiplier
